### PR TITLE
add libxml2(correct the earlier cve commit)

### DIFF
--- a/data/data_v2.json
+++ b/data/data_v2.json
@@ -2451,75 +2451,23 @@
     "poc_cmd": "./poc.sh"
   },
   {
-    "instance_id": "yilzhong_CVE-2018-5786",
-    "repo": "lrzip/lrzip",
-    "base_commit": "3495188cd8f2215a9feea201f3e05c1341ed95fb^",
-    "patch_commit": "3495188cd8f2215a9feea201f3e05c1341ed95fb",
-    "vuln_file": "lrzip.c",
+    "instance_id": "YilZhong_CVE-2017-5969",
+    "repo": "GNOME/libxml2",
+    "base_commit": "94691dc884d1a8ada39f073408b4bb92fe7fe882^",
+    "patch_commit": "94691dc884d1a8ada39f073408b4bb92fe7fe882",
+    "vuln_file": "valid.c",
     "vuln_lines": [
-      1093,
-      1134
+      1265,
+      1274
     ],
     "language": "c",
-    "vuln_source": "CVE-2018-5786",
-    "cwe_id": "CWE-835",
-    "vuln_type": "Infinite Loop",
+    "vuln_source": "CVE-2017-5969",
+    "cwe_id": "CWE-476",
+    "vuln_type": "Null Pointer Dereference",
     "severity": "medium",
-    "image": "choser/lrzip_cve-2018-5786:latest",
-    "image_name": "lrzip-cve-2018-5786",
-    "image_inner_path": "/workspace/lrzip",
-    "image_run_cmd": "tail -f /dev/null",
-    "image_status_check_cmd": "bash -c './setup.sh && ./image_status_check.sh'",
-    "test_case_cmd": "./test_case.sh",
-    "poc_cmd": "./poc.sh"
-  },
-  {
-    "instance_id": "yilzhong_CVE-2020-10251",
-    "repo": "ImageMagick/ImageMagick",
-    "base_commit": "868aad754ee599eb7153b84d610f2ecdf7b339f6^",
-    "patch_commit": "868aad754ee599eb7153b84d610f2ecdf7b339f6",
-    "vuln_file": "ImageMagick/ImageMagick/coders/heic.c",
-    "vuln_lines": [
-      4650,
-      4709
-    ],
-    "language": "c",
-    "vuln_source": "CVE-2020-10251",
-    "cwe_id": "CWE-125",
-    "vuln_type": "Out-of-bounds Read",
-    "severity": "medium",
-    "image": "choser/imagemagick_cve-2020-10251:latest",
-    "image_name": "imagemagick-cve-2020-10251",
-    "image_inner_path": "/workspace/ImageMagick",
-    "image_run_cmd": "tail -f /dev/null",
-    "image_status_check_cmd": "bash -c './setup.sh && ./image_status_check.sh'",
-    "test_case_cmd": "./test_case.sh",
-    "poc_cmd": "./poc.sh",
-    "other_vuln_files": [
-      {
-        "vuln_file": " ",
-        "vuln_lines": []
-      }
-    ]
-  },
-  {
-    "instance_id": "yilzhong_CVE-2019-20162",
-    "repo": "gpac/gpac",
-    "base_commit": "3c0ba42546c8148c51169c3908e845c308746c77^",
-    "patch_commit": "3c0ba42546c8148c51169c3908e845c308746c77",
-    "vuln_file": "gpac/src/isomedia/box_funcs.c",
-    "vuln_lines": [
-      99,
-      190
-    ],
-    "language": "c",
-    "vuln_source": "CVE-2019-20162",
-    "cwe_id": "CWE-787",
-    "vuln_type": "Out-of-bounds Write",
-    "severity": "medium",
-    "image": "choser/gpac_cve-2019-20162:latest",
-    "image_name": "gpac-cve-2019-20162",
-    "image_inner_path": "/workspace/gpac",
+    "image": "choser/libxml2-cve-2017-5969:latest",
+    "image_name": "libxml2-cve-2017-5969",
+    "image_inner_path": "/workspace/libxml2",
     "image_run_cmd": "tail -f /dev/null",
     "image_status_check_cmd": "bash -c './setup.sh && ./image_status_check.sh'",
     "test_case_cmd": "./test_case.sh",


### PR DESCRIPTION
#49 
镜像和 PoC 都跑通，CWE-476 一条记录，轻量但代表性够，希望能帮大家把 NPD 的覆盖度再提一格。若格式需要微调，随时call我。

CVE 统计：1 条（CVE-2017-5969）
CWE 统计：CWE-476 ×1
（此前提交有误，现修正）