### PR TITLE
Add CVE-2020-27750 vulnerability details in JSON

### DIFF
--- a/data/CVE-2020-27750.json
+++ b/data/CVE-2020-27750.json
@@ -1,0 +1,31 @@
+{
+    "instance_id": "Choser_CVE-2020-27750",
+    "repo": "ImageMagick/ImageMagick",
+    "base_commit": "a81ca9a1b46a96be83682af3389f0a6f3d0d389d^",
+    "patch_commit": "a81ca9a1b46a96be83682af3389f0a6f3d0d389d",
+    "vuln_file": "MagickCore/colorspace-private.h",
+    "vuln_lines": [
+      77,
+      81
+    ],
+    "language": "c",
+    "vuln_source": "CVE-2020-27750",
+    "cwe_id": "CWE-369",
+    "vuln_type": "Divide By Zero",
+    "severity": "medium",
+    "image": "choser/imagemagick_cve-2020-27750:latest",
+    "image_name": "imagemagick_cve-2020-27750",
+    "image_inner_path": "/workspace/ImageMagick",
+    "image_run_cmd": "tail -f /dev/null",
+    "image_status_check_cmd": "bash -c './setup.sh && ./image_status_check.sh'",
+    "test_case_cmd": "./test_case.sh",
+    "poc_cmd": "./poc.sh",
+    "other_vuln_files": [
+      {
+        "vuln_file": "MagickWand/pixel-iterator.c",
+        "vuln_lines": [
+          920,
+          927
+        ]
+      }]
+  }


### PR DESCRIPTION
Ref #91
Data file: data/CVE-2020-27750.json
Validation: passed (see logs in Issue #91 )
Source: ImageMagick