### PR TITLE
Add CVE-2019-11472 vulnerability details

### DIFF
--- a/data/CVE-2019-11472.json
+++ b/data/CVE-2019-11472.json
@@ -1,0 +1,24 @@
+{
+    "instance_id": "Choser_CVE-2019-11472",
+    "repo": "ImageMagick/ImageMagick",
+    "base_commit": "ab3e2be9b387919ef5c25977c4c054fb9dc089a6^",
+    "patch_commit": "ab3e2be9b387919ef5c25977c4c054fb9dc089a6",
+    "vuln_file": "coders/xwd.c",
+    "vuln_lines": [
+      245,
+      249
+    ],
+    "language": "c",
+    "vuln_source": "CVE-2019-11472",
+    "cwe_id": "CWE-369",
+    "vuln_type": "Divide By Zero",
+    "severity": "medium",
+    "image": "choser/imagemagick_cve-2019-11472:latest",
+    "image_name": "imagemagick_cve-2019-11472",
+    "image_inner_path": "/workspace/ImageMagick",
+    "image_run_cmd": "tail -f /dev/null",
+    "image_status_check_cmd": "bash -c './setup.sh && ./image_status_check.sh'",
+    "test_case_cmd": "./test_case.sh",
+    "poc_cmd": "./poc.sh",
+    "other_vuln_files": []
+  }


### PR DESCRIPTION
Ref #93
Data file: data/CVE-2019-11472.json
Validation: passed (see logs in Issue #93  )
Source: ImageMagick