### PR TITLE
Create CVE-2020-27757.json

### DIFF
--- a/data/CVE-2020-27757.json
+++ b/data/CVE-2020-27757.json
@@ -1,0 +1,24 @@
+{
+    "instance_id": "Choser_CVE-2020-27757",
+    "repo": "ImageMagick/ImageMagick",
+    "base_commit": "e88532bd4418e95b70cbc415fe911d22ab27a5fd^",
+    "patch_commit": "e88532bd4418e95b70cbc415fe911d22ab27a5fd",
+    "vuln_file": "MagickCore/quantum-private.h",
+    "vuln_lines": [
+      326,
+      329
+    ],
+    "language": "c",
+    "vuln_source": "CVE-2020-27757",
+    "cwe_id": "CWE-190",
+    "vuln_type": "Integer Overflow",
+    "severity": "low",
+    "image": "choser/imagemagick_cve-2020-27757:latest",
+    "image_name": "imagemagick_cve-2020-27757",
+    "image_inner_path": "/workspace/ImageMagick",
+    "image_run_cmd": "tail -f /dev/null",
+    "image_status_check_cmd": "bash -c './setup.sh && ./image_status_check.sh'",
+    "test_case_cmd": "./test_case.sh",
+    "poc_cmd": "./poc.sh",
+    "other_vuln_files": []
+  }


### PR DESCRIPTION
Ref #92
Data file: data/CVE-2020-27757.json
Validation: passed (see logs in Issue #92 )
Source: ImageMagick