### PR TITLE
fix: guard against empty choices and message=None in LLM API calls

### DIFF
--- a/bench/context_manager.py
+++ b/bench/context_manager.py
@@ -192,6 +192,8 @@ class ContextManager:
                     {"role": "user", "content": user_message},
                 ]
             )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         function_summary = response.choices[0].message.content.strip()
         return function_summary
 
@@ -245,6 +247,8 @@ class ContextManager:
             temperature=temperature,
             max_tokens=max_gen_token,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         text = response.choices[0].message.content or ""
         text = self._strip_code_fences(text)
 

--- a/bench/generate_code.py
+++ b/bench/generate_code.py
@@ -490,6 +490,8 @@ def call_llm(base_url, openai_key, model_name, system_message, user_message, max
             final_answer += answer_chunk
         return final_answer
     else:
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         completion = response.choices[0].message.content.strip()
         return completion
 


### PR DESCRIPTION
## What

Add explicit guards at three LLM call sites in `bench/context_manager.py` and `bench/generate_code.py` before accessing `response.choices[0].message.content`.

## Why

`openai.chat.completions.create()` can return two empty-response shapes:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures  
2. **`choices[0].message = None`** — e.g. Gemini 2.5 Flash (via OpenAI-compatible endpoint) returns HTTP 200 with `finish_reason: PROHIBITED_CONTENT` and `message=None`

Both crash with `IndexError` or `AttributeError`. For a security evaluation benchmark that may call various LLM providers including Gemini-compatible endpoints, these crashes degrade benchmark accuracy.

## Change

```python
# Before
function_summary = response.choices[0].message.content.strip()

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
function_summary = response.choices[0].message.content.strip()
```

Applied at: `generate_function_summary()`, `generate_hypothetical_patch()` (both in `context_manager.py`), and the non-streaming path in `generate_code.py`.

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.8k violations in 800+ repos.